### PR TITLE
Refactored WhereOptions type for improved type-safety

### DIFF
--- a/src/sql.builders.ts
+++ b/src/sql.builders.ts
@@ -267,7 +267,7 @@ export class WhereQuery<Tables extends Constructor<any>[]> implements SqlBuilder
             const sql = assertSql(options.call(this, ...this.refs))
             return this.condition('AND', sql)
         } else {
-            return this.condition('AND', options as WhereOptions<InstanceType<ArrayToElementType<Tables>>>) 
+            return this.condition('AND', options as WhereOptions<ArrayToElementType<Tables>>) 
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,13 +28,6 @@ export type ConstructorToInstances<T> = {
 
 export type Params = Record<string, any> | any[];
 
-export type ScalarValue = 
-    | string
-    | bigint
-    | number
-    | boolean
-    | null
-    | symbol
 export type DbBinding =
     | string
     | bigint
@@ -215,21 +208,21 @@ export interface SqlBuilder {
     build(): Fragment
 }
 
-export type WhereOptions<T> = {
-    equals?:     Partial<Record<keyof T,ScalarValue>>
-    notEquals?:  Partial<Record<keyof T,ScalarValue>>
-    like?:       Partial<Record<keyof T,ScalarValue>>
-    notLike?:    Partial<Record<keyof T,ScalarValue>>
-    startsWith?: Partial<Record<keyof T,ScalarValue>>
-    endsWith?:   Partial<Record<keyof T,ScalarValue>>
-    contains?:   Partial<Record<keyof T,ScalarValue>>
-    in?:         Partial<Record<keyof T,ScalarValue[]>>
-    notIn?:      Partial<Record<keyof T,ScalarValue[]>>
-    isNull?:     string[]
-    notNull?:    string[]
-    op?:         [string, Partial<Record<keyof T,any>>]
+export type WhereOptions<T extends object> = {
+    equals?:     { [K in keyof T]?: T[K] }
+    notEquals?:  { [K in keyof T]?: T[K] }
+    like?:       { [K in keyof T]?: T[K] }
+    notLike?:    { [K in keyof T]?: T[K] }
+    startsWith?: { [K in keyof T]?: T[K] }
+    endsWith?:   { [K in keyof T]?: T[K] }
+    contains?:   { [K in keyof T]?: T[K] }
+    in?:         { [K in keyof T]?: T[K][] }
+    notIn?:      { [K in keyof T]?: T[K][] }
+    isNull?:     (keyof T)[]
+    notNull?:    (keyof T)[]
+    op?:         [string, { [K in keyof T]?: T[K] }]
     rawSql?:     string|string[]
-    params?:     Partial<Record<keyof T,any>>
+    params?:     Record<string,any>
 }
 
 export type JoinType = "JOIN" | "INNER JOIN" | "LEFT JOIN" | "RIGHT JOIN" | "OUTER JOIN" | "FULL JOIN" | "CROSS JOIN"

--- a/test/where.sqlite.test.ts
+++ b/test/where.sqlite.test.ts
@@ -26,6 +26,8 @@ describe('SQLite WHERE Tests', () => {
             age: 27,
             city: 'Austin'
         }
+        const props = Object.keys(search) as (keyof typeof search)[]
+
         expect(str($.from(Contact).where({ equals: search })))
             .toContain(`WHERE ${qFirstName} = $firstName AND ${qAge} = $age AND ${qCity} = $city`)
         expect(str($.from(Contact).where({ notEquals: search })))
@@ -63,10 +65,10 @@ describe('SQLite WHERE Tests', () => {
             .toContain(`WHERE ${qId} NOT IN ($_1,$_2,$_3)`)
         expect(qNotIn.params).toEqual({ _1:10, _2:20, _3:30 })
 
-        expect(str($.from(Contact).where({ isNull: Object.keys(search) })))
+        expect(str($.from(Contact).where({ isNull: props })))
             .toContain(`WHERE ${qFirstName} IS NULL AND ${qAge} IS NULL AND ${qCity} IS NULL`)
 
-        expect(str($.from(Contact).where({ notNull: Object.keys(search) })))
+        expect(str($.from(Contact).where({ notNull: ['firstName','age','city'] })))
             .toContain(`WHERE ${qFirstName} IS NOT NULL AND ${qAge} IS NOT NULL AND ${qCity} IS NOT NULL`)
     })
 
@@ -76,6 +78,7 @@ describe('SQLite WHERE Tests', () => {
             age: 27,
             city: 'Austin'
         }
+        const props = Object.keys(search) as (keyof typeof search)[]
 
         expect(str($.from(Contact).where({ equals: search })))
             .toContain(`WHERE ${qFirstName} = $firstName AND ${qAge} = $age AND ${qCity} = $city`)
@@ -110,10 +113,10 @@ describe('SQLite WHERE Tests', () => {
         expect(str($.from(Contact).where({ notIn: { id:[10,20,30] } })))
             .toContain(`WHERE ${qId} NOT IN ($_1,$_2,$_3)`)
 
-        expect(str($.from(Contact).where({ isNull: Object.keys(search) })))
+        expect(str($.from(Contact).where({ isNull: props })))
             .toContain(`WHERE ${qFirstName} IS NULL AND ${qAge} IS NULL AND ${qCity} IS NULL`)
 
-        expect(str($.from(Contact).where({ notNull: Object.keys(search) })))
+        expect(str($.from(Contact).where({ notNull: props })))
             .toContain(`WHERE ${qFirstName} IS NOT NULL AND ${qAge} IS NOT NULL AND ${qCity} IS NOT NULL`)
     })
 
@@ -140,7 +143,7 @@ describe('SQLite WHERE Tests', () => {
             age: 27,
             city: 'Austin'
         }
-        const props = Object.keys(search)
+        const props = Object.keys(search) as (keyof typeof search)[]
 
         const { firstName, age, city } = search
 


### PR DESCRIPTION
1. Use of TypeScript's Indexed Access Types in WhereOptions (equals, notEquals, like, notLike, startsWith, endsWith, contains, in, notIn, op) allows strong-typing in the property value. ScalarValue is no longer needed! The following code would now be a TypeScript error:
`$.from(Contact).where({ equals: {firstName: 100} })  // <-- firstName is a string not a number`

2. Use of TypeScript's Indexed Access Types in WhereOptions (isNull, notNull). The following code would now be a TypeScript error:
`$.from(Contact).where({ notIn: { id:['10','20','30'] } })  // <-- id is a number not a string`

3. Fixed other type errors.